### PR TITLE
git github actions working with hcp vault

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,7 @@ jobs:
         roleId: ${{ secrets.ROLE_ID }}
         secretId: ${{ secrets.SECRET_ID }}
         tlsSkipVerify: true
+        exportEnv: false
         namespace: admin
         secrets: |
           gcp/key/tf-acctest private_key_data


### PR DESCRIPTION
Adding this vault-action in should authenticate us to vault with this approle, allowing us read-only access to our gcp/key/tf-acctest secret_key which we will later export for our tests to use as our credentials.