### PR TITLE
fix domain datasource tests

### DIFF
--- a/internal/provider/data_source_domain.go
+++ b/internal/provider/data_source_domain.go
@@ -8,13 +8,16 @@ import (
 )
 
 func dataSourceDomain() *schema.Resource {
+	dsSchema := datasourceSchemaFromResourceSchema(resourceDomain().Schema)
+	addRequiredFieldsToSchema(dsSchema, "domain_name")
+
 	return &schema.Resource{
 		// This description is used by the documentation generator and the language server.
 		Description: "Domain data source in the Terraform Googleworkspace provider.",
 
 		ReadContext: dataSourceDomainRead,
 
-		Schema: resourceDomain().Schema,
+		Schema: dsSchema,
 	}
 }
 

--- a/internal/provider/data_source_domain_test.go
+++ b/internal/provider/data_source_domain_test.go
@@ -31,6 +31,8 @@ resource "googleworkspace_domain" "my-domain" {
 
 data "googleworkspace_domain" "my-domain" {
   domain_name = googleworkspace_domain.my-domain.domain_name
+
+  depends_on = [googleworkspace_domain.my-domain]
 }
 `, domainName)
 }


### PR DESCRIPTION
Fix domain datasource tests, turns out it was looking for the datasource before the resource created it, it just needed `depends_on`. I updated the dsSchema just to be consistent.

I think because `domain_name` was known before the resource was created, it didn't have to depend on the resource.

Fixed the `no "id" found in attributes` error