### PR TITLE
Revert change that checked out certain commits in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ on:
 #    paths-ignore:
 #      - 'README.md'
   push:
+    branches:
+      - main
     paths-ignore:
       - 'README.md'
   # For systems with an upstream API that could drift unexpectedly (like most SaaS systems, etc.),


### PR DESCRIPTION
Revert change that checked out certain commits, it didn't seem to be working, we'll continue to use the versions for now. Still only run GHA on push to `main` though.