### PR TITLE
update github actions timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,10 +102,10 @@ jobs:
         go test ./internal/provider -v -sweep=us-central1 -sweep-run= -timeout 60m
 
     - name: TF acceptance tests
-      timeout-minutes: 10
+      timeout-minutes: 120m
       env:
         TF_ACC: "1"
-        TF_LOG: "DEBUG"
+        TF_LOG: "TRACE"
         TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
 
         # Set whatever additional acceptance test env vars here. You can

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -32,4 +32,4 @@ test: fmtcheck
 # Run acceptance tests
 .PHONY: testacc
 testacc: fmtcheck
-	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test -count=1 $(TEST) -v $(TESTARGS) -timeout 120m -ldflags="-X=github.com/hashicorp/terraform-provider-googleworkspace/version.ProviderVersion=acc"
+	TF_ACC=1 go test -count=1 $(TEST) -v $(TESTARGS) -timeout 120m

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -32,4 +32,4 @@ test: fmtcheck
 # Run acceptance tests
 .PHONY: testacc
 testacc: fmtcheck
-	TF_ACC=1 go test -count=1 $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test -count=1 $(TEST) -v $(TESTARGS) -timeout 120m -ldflags="-X=github.com/hashicorp/terraform-provider-googleworkspace/version.ProviderVersion=acc"


### PR DESCRIPTION
Keep github actions from timing out, setting the same as the timeout in `make testacc`