### PR TITLE
use if_none_match for eventual consistency

### DIFF
--- a/internal/provider/eventual_consistency.go
+++ b/internal/provider/eventual_consistency.go
@@ -6,22 +6,15 @@ import (
 )
 
 // The number of consistent responses we want before we consider the resource consistent
-const numConsistent = 3
+const numConsistent = 4
 
 type consistencyCheck struct {
 	currConsistent int
-	previousEtags  []string
+	etagChanges    int
+	lastEtag       string
 	resourceType   string
 	// timeout should be set to the timeout of the action
 	timeout time.Duration
-}
-
-func (cc *consistencyCheck) inPreviousEtags(etag string) bool {
-	return stringInSlice(cc.previousEtags, etag)
-}
-
-func (cc *consistencyCheck) isConsistentWithLastEtag(etag string) bool {
-	return cc.previousEtags[len(cc.previousEtags)-1] == etag
 }
 
 func (cc *consistencyCheck) reachedConsistency(numInserts int) bool {
@@ -36,49 +29,13 @@ func (cc *consistencyCheck) reachedConsistency(numInserts int) bool {
 	// so that it checks that at least the last half of responses were consistent
 	maxConsistent := int(cc.timeout.Minutes()) * 6 / 2
 
-	return (cc.currConsistent == numConsistent && len(cc.previousEtags) >= numInserts) ||
+	return (cc.currConsistent == numConsistent && cc.etagChanges >= numInserts) ||
 		cc.currConsistent >= maxConsistent
 }
 
-func (cc *consistencyCheck) handleFirstRun(etag string) error {
-	if len(cc.previousEtags) == 0 {
-		cc.previousEtags = append(cc.previousEtags, etag)
-		cc.currConsistent = 0
-		return fmt.Errorf("timed out while waiting for %s to be inserted (%d/%d consistent etags)", cc.resourceType, cc.currConsistent, numConsistent)
-	}
-
-	return nil
-}
-
-func (cc *consistencyCheck) checkChangedEtags(numInserts int, etag string) error {
-	if len(cc.previousEtags) >= numInserts {
-		// We've seen the number of changes we're expecting,
-		// check if this etag is consistent with the last
-		if cc.isConsistentWithLastEtag(etag) {
-			// We got another consistent tag
-			cc.currConsistent += 1
-		} else if !cc.inPreviousEtags(etag) {
-			// on create, this is possible since the etag changes with every request
-			cc.currConsistent = 0
-			cc.previousEtags = append(cc.previousEtags, etag)
-		}
-
-		return fmt.Errorf("timed out while waiting for %s to be inserted (%d/%d consistent etags)", cc.resourceType, cc.currConsistent, numConsistent)
-	}
-
-	return nil
-}
-
-func (cc *consistencyCheck) handleConsistency(etag string) {
-	if cc.isConsistentWithLastEtag(etag) {
-		// We have a consistent tag, but haven't hit our ration of etags:numInserts, we're counting these just
-		// in case we need to check maxConsistent (see reachedConsistency code)
-		cc.currConsistent += 1
-	}
-
-	if !cc.isConsistentWithLastEtag(etag) && !cc.inPreviousEtags(etag) {
-		// A new Etag! Working our way toward our new etags:numInserts ratio
-		cc.currConsistent = 0
-		cc.previousEtags = append(cc.previousEtags, etag)
-	}
+func (cc *consistencyCheck) handleNewEtag(etag string) error {
+	cc.currConsistent = 0
+	cc.lastEtag = etag
+	cc.etagChanges += 1
+	return fmt.Errorf("timed out while waiting for %s to be inserted (%d/%d consistent etags)", cc.resourceType, cc.currConsistent, numConsistent)
 }

--- a/internal/provider/eventual_consistency_test.go
+++ b/internal/provider/eventual_consistency_test.go
@@ -1,52 +1,9 @@
 package googleworkspace
 
 import (
-	"reflect"
 	"testing"
 	"time"
 )
-
-func TestConsistencyCheckInPreviousEtags(t *testing.T) {
-	cc := consistencyCheck{
-		previousEtags: []string{
-			"12345",
-			"abcde",
-			"10987",
-			"zyxwv",
-		},
-	}
-
-	if cc.inPreviousEtags("a1b2c3") {
-		t.Errorf("Failed ['a1b2c3']: result ('a1b2c3') was found in previous etags (%s)", cc.previousEtags)
-	}
-
-	if !cc.inPreviousEtags("12345") {
-		t.Errorf("Failed ['12345']: result ('12345') was not found in previous etags (%s)", cc.previousEtags)
-	}
-}
-
-func TestConsistencyCheckIsConsistentWithLastEtag(t *testing.T) {
-	cc := consistencyCheck{
-		previousEtags: []string{
-			"12345",
-			"abcde",
-			"10987",
-			"zyxwv",
-		},
-	}
-
-	if cc.isConsistentWithLastEtag("a1b2c3") {
-		t.Errorf("Failed ['a1b2c3']: result ('a1b2c3') was consistent with last etag (%s)", cc.previousEtags[3])
-	}
-
-	if cc.isConsistentWithLastEtag("12345") {
-		t.Errorf("Failed ['12345']: result ('12345') was consistent with last etag (%s)", cc.previousEtags[3])
-	}
-
-	if !cc.isConsistentWithLastEtag("zyxwv") {
-		t.Errorf("Failed ['zyxwv']: result ('zyxwv') was not consistent with last etag (%s)", cc.previousEtags[3])
-	}
-}
 
 func TestConsistencyCheckReachedConsistency(t *testing.T) {
 	// We'll test that there were 3 inserts
@@ -55,162 +12,58 @@ func TestConsistencyCheckReachedConsistency(t *testing.T) {
 	cc := consistencyCheck{
 		timeout:        time.Duration(time.Minute * 5),
 		currConsistent: 1,
-		previousEtags: []string{
-			"12345",
-		},
+		etagChanges:    1,
+		lastEtag:       "12345",
 	}
 
 	// So far we've seen one etag and it's been consistent once
 	if cc.reachedConsistency(numInserts) {
-		t.Errorf("Failed: reached consistency (numInserts: %d, currConsistent: %d, len(etags): %d, timeout: %d)", numInserts, cc.currConsistent, len(cc.previousEtags), int(cc.timeout.Minutes()))
+		t.Errorf("Failed: reached consistency (numInserts: %d, currConsistent: %d, etagChanges: %d, timeout: %d)", numInserts, cc.currConsistent, cc.etagChanges, int(cc.timeout.Minutes()))
 	}
 
 	// We only have 2 previous Etags, but we've been consistent for 3 minutes
 	// We'll assume it's consistent and that one of the inserts already contained
 	// and updated etag that we're missing
-	cc.previousEtags = append(cc.previousEtags, "abcde")
+	cc.etagChanges = 2
 	cc.currConsistent = 18
 
 	if !cc.reachedConsistency(numInserts) {
-		t.Errorf("Failed: did not reach consistency (numInserts: %d, currConsistent: %d, len(etags): %d, timeout: %d)", numInserts, cc.currConsistent, len(cc.previousEtags), int(cc.timeout.Minutes()))
+		t.Errorf("Failed: did not reach consistency (numInserts: %d, currConsistent: %d, etagChanges: %d, timeout: %d)", numInserts, cc.currConsistent, cc.etagChanges, int(cc.timeout.Minutes()))
 	}
 
-	// We've seen all the inserts come through, but we haven't had 3 consistent tags yet
-	cc.previousEtags = append(cc.previousEtags, "10987")
+	// We've seen all the inserts come through, but we haven't had 4 consistent tags yet
+	cc.etagChanges = 3
 	cc.currConsistent = 1
 
 	if cc.reachedConsistency(numInserts) {
-		t.Errorf("Failed: reached consistency (numInserts: %d, currConsistent: %d, len(etags): %d, timeout: %d)", numInserts, cc.currConsistent, len(cc.previousEtags), int(cc.timeout.Minutes()))
+		t.Errorf("Failed: reached consistency (numInserts: %d, currConsistent: %d, etagChanges: %d, timeout: %d)", numInserts, cc.currConsistent, cc.etagChanges, int(cc.timeout.Minutes()))
 	}
 
-	// We've seen all the inserts come through, but and it's been consistent 3 times
-	cc.currConsistent = 3
+	// We've seen all the inserts come through, and it's been consistent 4 times
+	cc.currConsistent = 4
 
 	if !cc.reachedConsistency(numInserts) {
-		t.Errorf("Failed: did not reach consistency (numInserts: %d, currConsistent: %d, len(etags): %d, timeout: %d)", numInserts, cc.currConsistent, len(cc.previousEtags), int(cc.timeout.Minutes()))
+		t.Errorf("Failed: did not reach consistency (numInserts: %d, currConsistent: %d, etagChanges: %d, timeout: %d)", numInserts, cc.currConsistent, cc.etagChanges, int(cc.timeout.Minutes()))
 	}
 }
 
-func TestConsistencyCheckFirstRun(t *testing.T) {
+func TestConsistencyHandleNewEtag(t *testing.T) {
 	cc := consistencyCheck{
 		resourceType: "test",
 	}
 
-	err := cc.handleFirstRun("12345")
-	if err == nil {
-		t.Errorf("Failed ['12345']: did not return an error on first run (%s)", cc.previousEtags)
+	cc.handleNewEtag("12345")
+	if cc.currConsistent != 0 {
+		t.Errorf("Failed ['12345']: new etag shows currConsistent > 0 (%d)", cc.currConsistent)
 	}
 
-	err = cc.handleFirstRun("abcde")
-	if err != nil {
-		t.Errorf("Failed ['abcde']: returned an error on first run (%s)", cc.previousEtags)
-	}
-}
-
-func TestConsistencyCheckCheckChangedEtags(t *testing.T) {
-	// We'll test that there were 3 inserts
-	numInserts := 2
-
-	cc := consistencyCheck{
-		resourceType:   "test",
-		currConsistent: 0,
-		previousEtags: []string{
-			"12345",
-		},
+	cc.handleNewEtag("abcde")
+	if cc.lastEtag != "abcde" {
+		t.Errorf("Failed ['abcde']: ends with incorrect lastEtag (%s)", cc.lastEtag)
 	}
 
-	// We haven't hit every insert yet, we should pass through this
-	err := cc.checkChangedEtags(numInserts, "abcde")
-	if err != nil {
-		t.Errorf("Failed ['abcde']: previousEtags (%+v) does not include all inserts (%d) yet, but we received an error", cc.previousEtags, numInserts)
-	}
-
-	expectedEtags := []string{"12345"}
-	expectedConsistent := 0
-
-	if !reflect.DeepEqual(expectedEtags, cc.previousEtags) || expectedConsistent != cc.currConsistent {
-		t.Errorf("Failed ['abcde']: previousEtags (%+v) or currConsistent (%d) did not match expected (%+v, %d)", cc.previousEtags, cc.currConsistent, expectedEtags, expectedConsistent)
-	}
-
-	cc.previousEtags = append(cc.previousEtags, "abcde")
-
-	// We've seen all inserts, but receive a brand new etag, we should append it to previousEtags and restart currConsistent
-	err = cc.checkChangedEtags(numInserts, "zyxwv")
-	if err == nil {
-		t.Errorf("Failed ['zyxwv']: previousEtags (%+v) received new etag (%s), but we did not receive an error", cc.previousEtags, "zyxwv")
-	}
-
-	expectedEtags = []string{"12345", "abcde", "zyxwv"}
-	expectedConsistent = 0
-
-	if !reflect.DeepEqual(expectedEtags, cc.previousEtags) || expectedConsistent != cc.currConsistent {
-		t.Errorf("Failed ['zyxwv']: previousEtags (%+v) or currConsistent (%d) did not match expected (%+v, %d)", cc.previousEtags, cc.currConsistent, expectedEtags, expectedConsistent)
-	}
-
-	// We've seen all inserts, and receive an etag consistent with the last one, update currConsistent
-	err = cc.checkChangedEtags(numInserts, "zyxwv")
-	if err == nil {
-		t.Errorf("Failed ['zyxwv']: previousEtags (%+v) received a consistent etag (%s), but we did not receive an error", cc.previousEtags, "zyxwv")
-	}
-
-	expectedConsistent = 1
-
-	if !reflect.DeepEqual(expectedEtags, cc.previousEtags) || expectedConsistent != cc.currConsistent {
-		t.Errorf("Failed ['zyxwv']: previousEtags (%+v) or currConsistent (%d) did not match expected (%+v, %d)", cc.previousEtags, cc.currConsistent, expectedEtags, expectedConsistent)
-	}
-
-	// We've seen all inserts, and receive an etag that's not new, but not the last, we just need the error
-	err = cc.checkChangedEtags(numInserts, "12345")
-	if err == nil {
-		t.Errorf("Failed ['12345']: previousEtags (%+v) received an etag (%s) its seen previously, but not last, but we did not receive an error", cc.previousEtags, "zyxwv")
-	}
-
-	if !reflect.DeepEqual(expectedEtags, cc.previousEtags) || expectedConsistent != cc.currConsistent {
-		t.Errorf("Failed ['12345']: previousEtags (%+v) or currConsistent (%d) did not match expected (%+v, %d)", cc.previousEtags, cc.currConsistent, expectedEtags, expectedConsistent)
-	}
-}
-
-func TestConsistencyCheckConsistency(t *testing.T) {
-	cc := consistencyCheck{
-		resourceType:   "test",
-		currConsistent: 0,
-		previousEtags: []string{
-			"12345",
-		},
-	}
-
-	// A brand new etag should be appended to previousEtags
-	cc.handleConsistency("abcde")
-
-	expectedEtags := []string{"12345", "abcde"}
-	expectedConsistent := 0
-
-	if !reflect.DeepEqual(expectedEtags, cc.previousEtags) || expectedConsistent != cc.currConsistent {
-		t.Errorf("Failed ['abcde']: previousEtags (%+v) or currConsistent (%d) did not match expected (%+v, %d)", cc.previousEtags, cc.currConsistent, expectedEtags, expectedConsistent)
-	}
-
-	// An old etag, but not consistent with the last, we should see no updates
-	cc.handleConsistency("12345")
-
-	if !reflect.DeepEqual(expectedEtags, cc.previousEtags) || expectedConsistent != cc.currConsistent {
-		t.Errorf("Failed ['abcde']: previousEtags (%+v) or currConsistent (%d) did not match expected (%+v, %d)", cc.previousEtags, cc.currConsistent, expectedEtags, expectedConsistent)
-	}
-
-	// A consistent etag should update consistent by 1
-	cc.handleConsistency("abcde")
-
-	expectedConsistent = 1
-
-	if !reflect.DeepEqual(expectedEtags, cc.previousEtags) || expectedConsistent != cc.currConsistent {
-		t.Errorf("Failed ['abcde']: previousEtags (%+v) or currConsistent (%d) did not match expected (%+v, %d)", cc.previousEtags, cc.currConsistent, expectedEtags, expectedConsistent)
-	}
-
-	// A consistent etag should update consistent by 1
-	cc.handleConsistency("abcde")
-
-	expectedConsistent = 2
-
-	if !reflect.DeepEqual(expectedEtags, cc.previousEtags) || expectedConsistent != cc.currConsistent {
-		t.Errorf("Failed ['abcde']: previousEtags (%+v) or currConsistent (%d) did not match expected (%+v, %d)", cc.previousEtags, cc.currConsistent, expectedEtags, expectedConsistent)
+	cc.handleNewEtag("54321")
+	if cc.etagChanges != 3 {
+		t.Errorf("Failed ['abcde']: shows more/less etag changes (expected: %d, got: %d)", 3, cc.etagChanges)
 	}
 }


### PR DESCRIPTION
Update handling eventual consistency to hopefully fix most of the failing tests.  Uses `IfNoneMatch` and really simplifies things.

Also, bump `numConsistent` to 4