### PR TITLE
Fix panic

### DIFF
--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -171,6 +171,8 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		newGroup, retryErr := groupsService.Get(d.Id()).IfNoneMatch(cc.lastEtag).Do()
 		if googleapi.IsNotModified(retryErr) {
 			cc.currConsistent += 1
+		} else if retryErr != nil {
+			return fmt.Errorf("unexpected error during retries of %s: %s", cc.resourceType, retryErr)
 		} else {
 			cc.handleNewEtag(newGroup.Etag)
 		}
@@ -323,6 +325,8 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		newGroup, retryErr := groupsService.Get(d.Id()).IfNoneMatch(cc.lastEtag).Do()
 		if googleapi.IsNotModified(retryErr) {
 			cc.currConsistent += 1
+		} else if retryErr != nil {
+			return fmt.Errorf("unexpected error during retries of %s: %s", cc.resourceType, retryErr)
 		} else {
 			cc.handleNewEtag(newGroup.Etag)
 		}

--- a/internal/provider/resource_group_settings.go
+++ b/internal/provider/resource_group_settings.go
@@ -392,7 +392,10 @@ func resourceGroupSettingsCreate(ctx context.Context, d *schema.ResourceData, me
 	d.SetId(groupSettings.Email)
 
 	err = retryTimeDuration(ctx, d.Timeout(schema.TimeoutCreate), func() error {
-		newGroupSettings, _ := groupsService.Get(d.Id()).Do()
+		newGroupSettings, retryErr := groupsService.Get(d.Id()).Do()
+		if retryErr != nil {
+			return fmt.Errorf("unexpected error during retries of group settings: %s", retryErr)
+		}
 		if reflect.DeepEqual(groupSettings, newGroupSettings) {
 			return nil
 		}
@@ -661,7 +664,10 @@ func resourceGroupSettingsUpdate(ctx context.Context, d *schema.ResourceData, me
 	d.SetId(groupSettings.Email)
 
 	err = retryTimeDuration(ctx, d.Timeout(schema.TimeoutUpdate), func() error {
-		newGroupSettings, _ := groupsService.Get(d.Id()).Do()
+		newGroupSettings, retryErr := groupsService.Get(d.Id()).Do()
+		if retryErr != nil {
+			return fmt.Errorf("unexpected error during retries of group settings: %s", retryErr)
+		}
 		if reflect.DeepEqual(groupSettings, newGroupSettings) {
 			return nil
 		}

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -1094,6 +1094,8 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		newUser, retryErr := usersService.Get(d.Id()).IfNoneMatch(cc.lastEtag).Do()
 		if googleapi.IsNotModified(retryErr) {
 			cc.currConsistent += 1
+		} else if retryErr != nil {
+			return fmt.Errorf("unexpected error during retries of %s: %s", cc.resourceType, retryErr)
 		} else {
 			cc.handleNewEtag(newUser.Etag)
 		}
@@ -1444,6 +1446,8 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		newUser, retryErr := usersService.Get(d.Id()).IfNoneMatch(cc.lastEtag).Do()
 		if googleapi.IsNotModified(retryErr) {
 			cc.currConsistent += 1
+		} else if retryErr != nil {
+			return fmt.Errorf("unexpected error during retries of %s: %s", cc.resourceType, retryErr)
 		} else {
 			cc.handleNewEtag(newUser.Etag)
 		}


### PR DESCRIPTION
nil panics were a result of not checking if there was an error (and thus the pointers returned were nil). Let's bubble the errors up and catch them in the tests. It's possible I shouldn't have checked the errors of `group_settings` retries? Let's see what happens there.