### PR TITLE
Fix TYPE_MESSAGE validation bug in chrome policy resource

### DIFF
--- a/internal/provider/resource_chrome_policy_test.go
+++ b/internal/provider/resource_chrome_policy_test.go
@@ -34,6 +34,27 @@ func TestAccResourceChromePolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccResourceChromePolicy_typeMessage(t *testing.T) {
+	t.Parallel()
+
+	ouName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceChromePolicy_typeMessage(ouName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.#", "1"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_name", "chrome.users.ManagedBookmarksSetting"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_values.managedBookmarks", "{\"toplevelName\":\"Stuff\"}"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceChromePolicy_update(t *testing.T) {
 	t.Parallel()
 
@@ -249,4 +270,23 @@ resource "googleworkspace_chrome_policy" "test" {
   }
 }
 `, ouName, conns)
+}
+
+func testAccResourceChromePolicy_typeMessage(ouName string) string {
+	return fmt.Sprintf(`
+resource "googleworkspace_org_unit" "test" {
+  name = "%s"
+  parent_org_unit_path = "/"
+}
+
+resource "googleworkspace_chrome_policy" "test" {
+  org_unit_id = googleworkspace_org_unit.test.id
+  policies {
+    schema_name = "chrome.users.ManagedBookmarksSetting"
+    schema_values = {
+		managedBookmarks = "{\"toplevelName\":\"Stuff\"}"
+    }
+  }
+}
+`, ouName)
 }

--- a/internal/provider/retry_utils.go
+++ b/internal/provider/retry_utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -68,6 +69,12 @@ func IsRateLimitExceeded(err error) bool {
 		log.Printf("[DEBUG] Dismissed an error as retryable based on error code: %s", err)
 		return true
 	}
+
+	if gerr.Code == 403 && strings.Contains(gerr.Error(), "quotaExceeded") {
+		log.Printf("[DEBUG] Dismissed an error as retryable based on error code: %s", err)
+		return true
+	}
+
 	return false
 
 }


### PR DESCRIPTION
Several tests exceed ratelimits likely due to the aggressive parallelization, wrapped those calls with retry

Closes #111 