### PR TITLE
add handleNotFound errors to resources that were missing it

### DIFF
--- a/internal/provider/resource_gmail_send_as_alias.go
+++ b/internal/provider/resource_gmail_send_as_alias.go
@@ -258,7 +258,7 @@ func resourceGmailSendAsAliasDelete(ctx context.Context, d *schema.ResourceData,
 
 	err := sendAsAliasService.Delete("me", d.Get("send_as_email").(string)).Do()
 	if err != nil {
-		handleNotFoundError(err, d, d.Id())
+		return handleNotFoundError(err, d, d.Id())
 	}
 
 	log.Printf("[DEBUG] Finished deleting Gmail Send As Alias %q", d.Id())

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -207,7 +207,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	group, err := groupsService.Get(d.Id()).Do()
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(err, d, d.Get("email").(string))
 	}
 
 	d.Set("email", group.Email)
@@ -364,7 +364,7 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta inter
 
 	err := groupsService.Delete(d.Id()).Do()
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(err, d, d.Get("email").(string))
 	}
 
 	log.Printf("[DEBUG] Finished deleting Group %q: %#v", d.Id(), email)

--- a/internal/provider/resource_group_member.go
+++ b/internal/provider/resource_group_member.go
@@ -171,7 +171,7 @@ func resourceGroupMemberRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	member, err := membersService.Get(groupId, memberId).Do()
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(err, d, d.Id())
 	}
 
 	d.Set("email", member.Email)
@@ -264,7 +264,7 @@ func resourceGroupMemberDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	err := membersService.Delete(groupId, memberId).Do()
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(err, d, d.Id())
 	}
 
 	log.Printf("[DEBUG] Finished deleting Group Member %q: %#v", memberId, email)

--- a/internal/provider/resource_org_unit.go
+++ b/internal/provider/resource_org_unit.go
@@ -159,7 +159,7 @@ func resourceOrgUnitRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	orgUnit, err := orgUnitsService.Get(client.Customer, d.Id()).Do()
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(err, d, d.Id())
 	}
 
 	d.Set("name", orgUnit.Name)
@@ -249,7 +249,7 @@ func resourceOrgUnitDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 	err := orgUnitsService.Delete(client.Customer, d.Id()).Do()
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(err, d, d.Id())
 	}
 
 	log.Printf("[DEBUG] Finished deleting OrgUnit %q: %#v", d.Id(), ouName)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-googleworkspace/issues/132

There were a handful of resources that were returning the 404 error rather than clearing out the Id so the resource could be re-added.