### PR TITLE
obfuscate the access token from debug logs

### DIFF
--- a/internal/provider/logging_transport.go
+++ b/internal/provider/logging_transport.go
@@ -1,0 +1,112 @@
+package googleworkspace
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+)
+
+func getValuesToScrub() []string {
+	return []string{
+		"accessToken",
+	}
+}
+
+type loggingTransport struct {
+	name      string
+	transport http.RoundTripper
+}
+
+func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if logging.IsDebugOrHigher() {
+		reqData, err := httputil.DumpRequestOut(req, true)
+		if err == nil {
+			prettyPrint, err := prettyPrintJsonLines(reqData)
+			if err != nil {
+				return nil, err
+			}
+			log.Printf("[DEBUG] "+logReqMsg, t.name, prettyPrint)
+		} else {
+			log.Printf("[ERROR] %s API Request error: %#v", t.name, err)
+		}
+	}
+
+	resp, err := t.transport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	if logging.IsDebugOrHigher() {
+		respData, err := httputil.DumpResponse(resp, true)
+		if err == nil {
+			prettyPrint, err := prettyPrintJsonLines(respData)
+			if err != nil {
+				return nil, err
+			}
+			log.Printf("[DEBUG] "+logRespMsg, t.name, prettyPrint)
+		} else {
+			log.Printf("[ERROR] %s API Response error: %#v", t.name, err)
+		}
+	}
+
+	return resp, nil
+}
+
+func NewTransportWithScrubbedLogs(name string, t http.RoundTripper) *loggingTransport {
+	return &loggingTransport{name, t}
+}
+
+// prettyPrintJsonLines iterates through a []byte line-by-line,
+// transforming any lines that are complete json into pretty-printed json.
+// this was copied from the SDK's logging package
+func prettyPrintJsonLines(b []byte) (string, error) {
+	parts := strings.Split(string(b), "\n")
+	for i, p := range parts {
+		if b := []byte(p); json.Valid(b) {
+			var out bytes.Buffer
+
+			var jsonMap map[string]interface{}
+			err := json.Unmarshal(b, &jsonMap)
+			if err != nil {
+				return "", err
+			}
+
+			jsonMap = obfuscateValues(jsonMap)
+
+			b, err = json.Marshal(jsonMap)
+			if err != nil {
+				return "", err
+			}
+
+			json.Indent(&out, b, "", " ")
+			parts[i] = out.String()
+		}
+	}
+	return strings.Join(parts, "\n"), nil
+}
+
+func obfuscateValues(m map[string]interface{}) map[string]interface{} {
+	for _, v := range getValuesToScrub() {
+		if _, ok := m[v]; ok {
+			m[v] = "********"
+		}
+	}
+
+	return m
+}
+
+const logReqMsg = `%s API Request Details:
+---[ REQUEST ]---------------------------------------
+%s
+-----------------------------------------------------`
+
+const logRespMsg = `%s API Response Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`

--- a/internal/provider/provider_config.go
+++ b/internal/provider/provider_config.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 
 	"golang.org/x/oauth2"
 	googleoauth "golang.org/x/oauth2/google"
@@ -129,13 +128,13 @@ func (c *apiClient) SetupClient(ctx context.Context, creds *googleoauth.Credenti
 	}
 
 	// 2. Logging Transport - ensure we log HTTP requests to admin APIs.
-	loggingTransport := logging.NewTransport("Google Workspace", client.Transport)
+	scrubbedLoggingTransport := NewTransportWithScrubbedLogs("Google Workspace", client.Transport)
 
 	// 3. Retry Transport - retries common temporary errors
 	// Keep order for wrapping logging so we log each retried request as well.
 	// This value should be used if needed to create shallow copies with additional retry predicates.
 	// See ClientWithAdditionalRetries
-	retryTransport := NewTransportWithDefaultRetries(loggingTransport)
+	retryTransport := NewTransportWithDefaultRetries(scrubbedLoggingTransport)
 
 	// Set final transport value.
 	client.Transport = retryTransport


### PR DESCRIPTION
don't want to print out the accessToken in the response when debug is on!