### PR TITLE
Ensure that data source optional schema attributes will properly persist first time

### DIFF
--- a/internal/provider/datasource_helpers.go
+++ b/internal/provider/datasource_helpers.go
@@ -73,7 +73,7 @@ func addRequiredFieldsToSchema(schema map[string]*schema.Schema, keys ...string)
 // example) and the datasource could take one multiple inputs (say a unique name or a unique id)
 func addExactlyOneOfFieldsToSchema(schema map[string]*schema.Schema, keys ...string) {
 	for _, v := range keys {
-		schema[v].Computed = false
+		schema[v].Computed = true
 		schema[v].Optional = true
 		schema[v].Required = false
 		schema[v].ExactlyOneOf = keys


### PR DESCRIPTION
Fixes #217 

This will also fix similar behavior described in the pull request on `user` but also the 4 other similar `data` resources that re-used the either/or schema lookup via `addExactlyOneOfFieldsToSchema` function.  (user, group_member, group, org_unit, and schema)

/cc @megan07 