### PR TITLE
remove ability to import on create for group members

### DIFF
--- a/internal/provider/resource_group_member.go
+++ b/internal/provider/resource_group_member.go
@@ -149,7 +149,7 @@ func resourceGroupMemberCreate(ctx context.Context, d *schema.ResourceData, meta
 	member, err := membersService.Insert(groupId, &memberObj).Do()
 
 	// If we receive a 409 that the member already exists, ignore it, we'll import it next
-	if err != nil && !memberExistsError(err) {
+	if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_group_members.go
+++ b/internal/provider/resource_group_members.go
@@ -3,7 +3,6 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"google.golang.org/api/googleapi"
 	"log"
 	"reflect"
 	"strings"
@@ -166,8 +165,7 @@ func resourceGroupMembersCreate(ctx context.Context, d *schema.ResourceData, met
 		log.Printf("[DEBUG] Creating Group Member %q in group %s: %#v", memberObj.Email, groupId, memberObj.Email)
 
 		_, err := membersService.Insert(groupId, &memberObj).Do()
-		// If we receive a 409 that the member already exists, ignore it, we'll import it next
-		if err != nil && !memberExistsError(err) {
+		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -386,17 +384,4 @@ func resourceGroupMembersImport(ctx context.Context, d *schema.ResourceData, met
 	d.Set("group_id", parts[1])
 
 	return []*schema.ResourceData{d}, nil
-}
-
-func memberExistsError(err error) bool {
-	gerr, ok := err.(*googleapi.Error)
-	if !ok {
-		return false
-	}
-
-	if gerr.Code == 409 && strings.Contains(gerr.Body, "Member already exists") {
-		log.Printf("[DEBUG] Dismissed an error based on error code: %s", err)
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-googleworkspace/issues/216

Reverts fixes for https://github.com/hashicorp/terraform-provider-googleworkspace/issues/192 and https://github.com/hashicorp/terraform-provider-googleworkspace/issues/202

As noted in the related issues, we were trying to import on create to solve for some eventual consistency errors. After doing so, we realize we actually want to surface this error in the case that the member was added twice (potentially with two different roles). Thus we need to revert that functionality.

In the case it's eventual consistency, importing the named member will work.