### PR TITLE
Update release workflow for goreleaser extra_files remap support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,3 @@ jobs:
     with:
       release-notes: true
       setup-go-version: '${{ needs.go-version.outputs.version }}'
-      terraform-registry-manifest-source: 'terraform-registry-manifest.json'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,8 +28,8 @@ builds:
     mod_timestamp: '{{ .CommitTimestamp }}'
 checksum:
   extra_files:
-    # Cannot use templates (e.g. {{ .ProjectName }}_{{ .Version }}_manifest.json)
-    - glob: 'terraform-provider-*_*_manifest.json'
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 publishers:
@@ -45,8 +45,8 @@ publishers:
       - AWS_SESSION_TOKEN={{ .Env.AWS_SESSION_TOKEN }}
 release:
   extra_files:
-    # Cannot use templates (e.g. {{ .ProjectName }}_{{ .Version }}_manifest.json)
-    - glob: 'terraform-provider-*_*_manifest.json'
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   ids:
     - none
 signs:


### PR DESCRIPTION
Reference: https://github.com/goreleaser/goreleaser/issues/2656

`goreleaser` can now automatically remap file names natively during the checksum and release pipes.

Verified via:

- https://github.com/bflad/terraform-provider-framework/compare/v0.1.2...v0.1.3
- https://github.com/bflad/terraform-provider-framework/releases/tag/v0.1.3
- https://registry.terraform.io/providers/bflad/framework/0.1.3
