### PR TITLE
Update release workflow to point at hashicorp repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
   terraform-provider-release:
     name: 'Terraform Provider Release'
     needs: [go-version, release-notes]
-    uses: bflad/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@main
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v1
     secrets:
       hc-releases-aws-access-key-id: '${{ secrets.TF_PROVIDER_RELEASE_AWS_ACCESS_KEY_ID }}'
       hc-releases-aws-secret-access-key: '${{ secrets.TF_PROVIDER_RELEASE_AWS_SECRET_ACCESS_KEY }}'


### PR DESCRIPTION
The code is now under the `hashicorp` GitHub organization. There is also a `v1` tag available, which will automatically receive patch and minor updates.