### PR TITLE
Added include_derived_membership attribute to data source

### DIFF
--- a/docs/data-sources/group_members.md
+++ b/docs/data-sources/group_members.md
@@ -33,6 +33,10 @@ output "group_members" {
 
 - **group_id** (String) Identifies the group in the API request. The value can be the group's email address, group alias, or the unique group ID.
 
+### Optional
+
+- **include_derived_membership** (Boolean) If true, lists indirect group memberships
+
 ### Read-Only
 
 - **etag** (String) ETag of the resource.

--- a/internal/provider/data_source_group_members.go
+++ b/internal/provider/data_source_group_members.go
@@ -11,6 +11,11 @@ func dataSourceGroupMembers() *schema.Resource {
 	// Generate datasource schema from resource
 	dsSchema := datasourceSchemaFromResourceSchema(resourceGroupMembers().Schema)
 	addRequiredFieldsToSchema(dsSchema, "group_id")
+	dsSchema["include_derived_membership"] = &schema.Schema{
+		Description: "If true, lists indirect group memberships",
+		Type:        schema.TypeBool,
+		Optional:    true,
+	}
 
 	return &schema.Resource{
 		// This description is used by the documentation generator and the language server.

--- a/internal/provider/data_source_group_members_test.go
+++ b/internal/provider/data_source_group_members_test.go
@@ -19,16 +19,9 @@ func TestAccDataSourceGroupMembers(t *testing.T) {
 	}
 
 	testGroupVals := map[string]interface{}{
-		"userEmail":  fmt.Sprintf("tf-user-%s@%s", acctest.RandString(10), domainName),
-		"groupEmail": fmt.Sprintf("tf-group-%s@%s", acctest.RandString(10), domainName),
+		"userEmail":  fmt.Sprintf("tf-test-%s@%s", acctest.RandString(10), domainName),
+		"groupEmail": fmt.Sprintf("tf-test-%s@%s", acctest.RandString(10), domainName),
 		"password":   acctest.RandString(10),
-	}
-	testNestedGroupVals := map[string]interface{}{
-		"userEmail":     fmt.Sprintf("tf-user-%s@%s", acctest.RandString(10), domainName),
-		"subUserEmail":  fmt.Sprintf("tf-subuser-%s@%s", acctest.RandString(10), domainName),
-		"groupEmail":    fmt.Sprintf("tf-group-%s@%s", acctest.RandString(10), domainName),
-		"subGroupEmail": fmt.Sprintf("tf-subgroup-%s@%s", acctest.RandString(10), domainName),
-		"password":      acctest.RandString(10),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -48,6 +41,31 @@ func TestAccDataSourceGroupMembers(t *testing.T) {
 						}),
 				),
 			},
+		},
+	})
+}
+
+func TestAccDataSourceGroupMembersNested(t *testing.T) {
+	t.Parallel()
+
+	domainName := os.Getenv("GOOGLEWORKSPACE_DOMAIN")
+
+	if domainName == "" {
+		t.Skip("GOOGLEWORKSPACE_DOMAIN needs to be set to run this test")
+	}
+
+	testNestedGroupVals := map[string]interface{}{
+		"userEmail":     fmt.Sprintf("tf-test-%s@%s", acctest.RandString(10), domainName),
+		"subUserEmail":  fmt.Sprintf("tf-test-%s@%s", acctest.RandString(10), domainName),
+		"groupEmail":    fmt.Sprintf("tf-test-%s@%s", acctest.RandString(10), domainName),
+		"subGroupEmail": fmt.Sprintf("tf-test-%s@%s", acctest.RandString(10), domainName),
+		"password":      acctest.RandString(10),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNestedGroupMembers(testNestedGroupVals),
 				Check: resource.ComposeTestCheckFunc(

--- a/internal/provider/resource_group_members.go
+++ b/internal/provider/resource_group_members.go
@@ -44,7 +44,6 @@ func resourceGroupMembers() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-
 			"members": {
 				Description: "The members of the group",
 				Type:        schema.TypeSet,
@@ -192,9 +191,9 @@ func resourceGroupMembersRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	groupId := d.Get("group_id").(string)
-
+	includeDerivedMembership := d.Get("include_derived_membership").(bool)
 	var result []*directory.Member
-	membersCall := membersService.List(groupId).MaxResults(200)
+	membersCall := membersService.List(groupId).MaxResults(200).IncludeDerivedMembership(includeDerivedMembership)
 
 	err := membersCall.Pages(ctx, func(resp *directory.Members) error {
 		for _, member := range resp.Members {

--- a/internal/provider/resource_group_members.go
+++ b/internal/provider/resource_group_members.go
@@ -191,7 +191,13 @@ func resourceGroupMembersRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	groupId := d.Get("group_id").(string)
-	includeDerivedMembership := d.Get("include_derived_membership").(bool)
+	// include_derived_membership is a read-only option available in the datasource, but not in the resource
+	// because the datasource and resource share the same Read function, we can add it in here, but need to
+	// make sure it is always false for the resource
+	includeDerivedMembership := false
+	if includeDM, ok := d.GetOk("include_derived_membership"); ok {
+		includeDerivedMembership = includeDM.(bool)
+	}
 	var result []*directory.Member
 	membersCall := membersService.List(groupId).MaxResults(200).IncludeDerivedMembership(includeDerivedMembership)
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
Fixes #231 

Expose the option to include nested/derived group memberships in the data provider.

Example usage:
```hcl
data "googleworkspace_group" "team" {
  email = "team@example.com"
}

data "googleworkspace_group_members" "team" {
  group_id = data.googleworkspace_group.team.id
  include_derived_membership = true
}

output "members" {
  value = { for m in data.googleworkspace_group_members.team.members : m.email => m.type }
}
```