### PR TITLE
Update scope name for googleworkspace_users data source

### DIFF
--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -3,12 +3,12 @@
 page_title: "googleworkspace_users Data Source - terraform-provider-googleworkspace"
 subcategory: ""
 description: |-
-  Users data source in the Terraform Googleworkspace provider. Users resides under the https://www.googleapis.com/auth/admin.directory.users client scope.
+  Users data source in the Terraform Googleworkspace provider. Users resides under the https://www.googleapis.com/auth/admin.directory.user client scope.
 ---
 
 # googleworkspace_users (Data Source)
 
-Users data source in the Terraform Googleworkspace provider. Users resides under the `https://www.googleapis.com/auth/admin.directory.users` client scope.
+Users data source in the Terraform Googleworkspace provider. Users resides under the `https://www.googleapis.com/auth/admin.directory.user` client scope.
 
 ## Example Usage
 

--- a/internal/provider/data_source_users.go
+++ b/internal/provider/data_source_users.go
@@ -14,7 +14,7 @@ func dataSourceUsers() *schema.Resource {
 	return &schema.Resource{
 		// This description is used by the documentation generator and the language server.
 		Description: "Users data source in the Terraform Googleworkspace provider. Users resides " +
-			"under the `https://www.googleapis.com/auth/admin.directory.users` client scope.",
+			"under the `https://www.googleapis.com/auth/admin.directory.user` client scope.",
 
 		ReadContext: dataSourceUsersRead,
 


### PR DESCRIPTION
Using `https://www.googleapis.com/auth/admin.directory.users` results in an error while `https://www.googleapis.com/auth/admin.directory.user` works as expected.

Not sure if this scope existed before and was removed or it was a typo since the beginning.