### PR TITLE
Update goreleaser to publish manifest file via hc-releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,9 @@ checksum:
 publishers:
   - name: hc-releases
     checksum: true
+    extra_files:
+      - glob: 'terraform-registry-manifest.json'
+        name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
     signature: true
     cmd: hc-releases upload-file {{ abs .ArtifactPath }}
     env:


### PR DESCRIPTION
The recent goreleaser v1.3.0 release allows for custom publishers to declare `extra_files` configuration. This will allow us to upload the manifest file to releases.hashicorp.com, which should be ingested by the Terraform Registry to properly set protocol versions.