### PR TITLE
Make docs clearer by using sub-bullets

### DIFF
--- a/docs/resources/group_member.md
+++ b/docs/resources/group_member.md
@@ -46,10 +46,21 @@ resource "googleworkspace_group_member" "manager" {
 
 ### Optional
 
-- **delivery_settings** (String) Defines mail delivery preferences of member. Acceptable values are:`ALL_MAIL`: All messages, delivered as soon as they arrive. `DAILY`: No more than one message a day. `DIGEST`: Up to 25 messages bundled into a single message. `DISABLED`: Remove subscription. `NONE`: No messages. Defaults to `ALL_MAIL`.
-- **role** (String) The member's role in a group. The API returns an error for cycles in group memberships. For example, if group1 is a member of group2, group2 cannot be a member of group1. Acceptable values are: `MANAGER`: This role is only available if the Google Groups for Business is enabled using the Admin Console. A `MANAGER` role can do everything done by an `OWNER` role except make a member an `OWNER` or delete the group. A group can have multiple `MANAGER` members. `MEMBER`: This role can subscribe to a group, view discussion archives, and view the group's membership list. `OWNER`: This role can send messages to the group, add or remove members, change member roles, change group's settings, and delete the group. An OWNER must be a member of the group. A group can have more than one OWNER. Defaults to `MEMBER`.
+- **delivery_settings** (String) Defines mail delivery preferences of member. Acceptable values are:
+  - `ALL_MAIL`: (DEFAULT) All messages, delivered as soon as they arrive. 
+  - `DAILY`: No more than one message a day. 
+  - `DIGEST`: Up to 25 messages bundled into a single message. 
+  - `DISABLED`: Remove subscription. 
+  - `NONE`: No messages.
+- **role** (String) The member's role in a group. The API returns an error for cycles in group memberships. For example, if group1 is a member of group2, group2 cannot be a member of group1. Acceptable values are: 
+  - `MANAGER`: This role is only available if the Google Groups for Business is enabled using the Admin Console. A `MANAGER` role can do everything done by an `OWNER` role except make a member an `OWNER` or delete the group. A group can have multiple `MANAGER` members. 
+  - `MEMBER`: (DEFAULT) This role can subscribe to a group, view discussion archives, and view the group's membership list. 
+  - `OWNER`: This role can send messages to the group, add or remove members, change member roles, change group's settings, and delete the group. An OWNER must be a member of the group. A group can have more than one OWNER.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- **type** (String) The type of group member. Acceptable values are: `CUSTOMER`: The member represents all users in a domain. An email address is not returned and the ID returned is the customer ID. `GROUP`: The member is another group. `USER`: The member is a user. Defaults to `USER`.
+- **type** (String) The type of group member. Acceptable values are: 
+  - `CUSTOMER`: The member represents all users in a domain. An email address is not returned and the ID returned is the customer ID. 
+  - `GROUP`: The member is another group. 
+  - `USER`: (DEFAULT) The member is a user.
 
 ### Read-Only
 


### PR DESCRIPTION
Might want to address this more comprehensively instead, but I was just reading the docs page and noticed it was hard to follow with the existing formatting (particularly for the `MANAGER` section of the `role` field which has multiple code formatting snippets) so wanted to propose this formatting change.

I did not make any real content changes, just formatting adjustments.