### PR TITLE
Update user and group resource import snippets in the docs to use emails as identifiers

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -64,3 +64,9 @@ Import is supported using the following syntax:
 ```shell
 terraform import googleworkspace_group.sales {{email}}
 ```
+
+It is also possible to use an alphanumerical ID, which is present in the URL when viewing the Group's page in the Google Workspace UI:
+
+```shell
+terraform import googleworkspace_group.sales 01abcde23fg4h5i
+```

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -62,5 +62,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import googleworkspace_group.sales 01abcde23fg4h5i
+terraform import googleworkspace_group.sales {{email}}
 ```

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -403,3 +403,9 @@ Import is supported using the following syntax:
 ```shell
 terraform import googleworkspace_user.dwight {{primary_email}}
 ```
+
+It is also possible to use the Google Account's unique ID, a 21-digit number:
+
+```shell
+terraform import googleworkspace_user.dwight 123456789012345678901
+```

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -401,5 +401,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import googleworkspace_user.dwight 123456789012345678901
+terraform import googleworkspace_user.dwight {{primary_email}}
 ```


### PR DESCRIPTION
# Description

Fixes https://github.com/hashicorp/terraform-provider-googleworkspace/issues/266

The previous `import` snippets are correct but misleading to practitioners, especially due to how groups can be imported using part of their URL but users can't. And the numerical ID for users doesn't seem accessible in the Google Workspace UI.

Changing both snippets to suggest using email addresses, as they're easier to understand.