### PR TITLE
Add ability to set access_token via ENV variable

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -55,7 +55,10 @@ func New(version string) func() *schema.Provider {
 						"authenticate HTTP requests to Google Admin SDK APIs. This is an alternative to `credentials`, " +
 						"and ignores the `scopes` field. If both are specified, `access_token` will be " +
 						"used over the `credentials` field.",
-					Type:     schema.TypeString,
+					Type: schema.TypeString,
+					DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+						"GOOGLE_OAUTH_ACCESS_TOKEN",
+					}, nil),
 					Optional: true,
 				},
 


### PR DESCRIPTION
# Description

Closes https://github.com/hashicorp/terraform-provider-googleworkspace/issues/295

Allows the access_token argument to be set via an `GOOGLE_OAUTH_ACCESS_TOKEN` env variable

I manually tested locally that the ENV can be pulled in to configure the providers auth ok