### PR TITLE
Add acceptance tests checking the import of `user` and `group` resources by email

### DIFF
--- a/internal/provider/resource_group_test.go
+++ b/internal/provider/resource_group_test.go
@@ -63,6 +63,8 @@ func TestAccResourceGroup_basic(t *testing.T) {
 		"email":      fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
 	}
 
+	expectedEmail := fmt.Sprintf("%s@%s", testGroupVals["email"].(string), testGroupVals["domainName"].(string))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
@@ -71,8 +73,19 @@ func TestAccResourceGroup_basic(t *testing.T) {
 				Config: testAccResourceGroup_basic(testGroupVals),
 			},
 			{
+				// TestStep imports by `id` by default - an alphanumeric string
+				// https://developers.google.com/admin-sdk/directory/v1/guides/manage-groups#get_group
 				ResourceName:            "googleworkspace_group.my-group",
 				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+			{
+				// TestStep imports by `email`
+				// https://developers.google.com/admin-sdk/directory/v1/guides/manage-groups#get_group
+				ResourceName:            "googleworkspace_group.my-group",
+				ImportState:             true,
+				ImportStateId:           expectedEmail,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"etag"},
 			},

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -25,6 +25,8 @@ func TestAccResourceUser_basic(t *testing.T) {
 		"password":   acctest.RandString(10),
 	}
 
+	expectedEmail := fmt.Sprintf("%s@%s", testUserVals["userEmail"].(string), testUserVals["domainName"].(string))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
@@ -33,8 +35,19 @@ func TestAccResourceUser_basic(t *testing.T) {
 				Config: testAccResourceUser_basic(testUserVals),
 			},
 			{
+				// TestStep imports by `id` by default - a 21 digit number
+				// https://developers.google.com/admin-sdk/directory/v1/guides/manage-users#get_user
 				ResourceName:            "googleworkspace_user.my-new-user",
 				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag", "password"},
+			},
+			{
+				// TestStep imports by `primary_email`
+				// https://developers.google.com/admin-sdk/directory/v1/guides/manage-users#get_user
+				ResourceName:            "googleworkspace_user.my-new-user",
+				ImportState:             true,
+				ImportStateId:           expectedEmail,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"etag", "password"},
 			},

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/mail"
 	"os"
 	"reflect"
 	"sort"
@@ -196,4 +197,13 @@ func sortListOfInterfaces(v []interface{}) []string {
 	}
 	sort.Strings(newVal)
 	return newVal
+}
+
+// isEmail returns a boolean indicating if the input string is parsable as an email
+func isEmail(input string) bool {
+	_, err := mail.ParseAddress(input)
+	if err != nil {
+		return false
+	}
+	return true
 }

--- a/internal/provider/utils_test.go
+++ b/internal/provider/utils_test.go
@@ -37,3 +37,36 @@ func TestCamelToSnake(t *testing.T) {
 		}
 	}
 }
+
+func TestIsEmail(t *testing.T) {
+	type testCase struct {
+		input string
+		want  bool
+	}
+
+	tests := []testCase{
+		{
+			input: "",
+			want:  false,
+		},
+		{
+			input: "1234567890987654321",
+			want:  false,
+		},
+		{
+			input: "example.com",
+			want:  false,
+		},
+		{
+			input: "user@example.com",
+			want:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		got := isEmail(tc.input)
+		if tc.want != got {
+			t.Fatalf("expected: %v, got: %v", tc.want, got)
+		}
+	}
+}


### PR DESCRIPTION
# Description

Added tests that check the ability to import users and groups using their emails and assert that the stored `id` in state is the underlying ID within the API instead of the email.