### PR TITLE
Add acceptance test showing users can be provisioned without impersonation

### DIFF
--- a/.github/infra/workspace.tf
+++ b/.github/infra/workspace.tf
@@ -5,11 +5,20 @@ data "googleworkspace_role" "groups-admin" {
   name = "_GROUPS_ADMIN_ROLE"
 }
 
+data "googleworkspace_role" "user-management-admin" {
+  name = "_USER_MANAGEMENT_ADMIN_ROLE"
+}
+
 data "google_service_account" "vault-sa" {
   account_id = vault_gcp_secret_roleset.roleset.service_account_email
 }
 
 resource "googleworkspace_role_assignment" "sa-groups-admin" {
   role_id = data.googleworkspace_role.groups-admin.id
+  assigned_to = data.google_service_account.vault-sa.unique_id
+}
+
+resource "googleworkspace_role_assignment" "sa-user-managment-admin" {
+  role_id = data.googleworkspace_role.user-management-admin.id
   assigned_to = data.google_service_account.vault-sa.unique_id
 }

--- a/internal/provider/provider_no_impersonation_test.go
+++ b/internal/provider/provider_no_impersonation_test.go
@@ -10,6 +10,46 @@ import (
 )
 
 // this test requires the service account in the credentials file to have
+// GROUPS ADMIN role assignment. Use the rest api
+// "Try this API" https://developers.google.com/admin-sdk/directory/reference/rest/v1/roleAssignments/insert
+// you will need to determine the roleId of GROUPS ADMIN and use the client_id
+// in the credentials file as 'assignedTo', 'scopeType' should be 'CUSTOMER'
+func TestAccResourceGroup_noImpersonation(t *testing.T) {
+	domainName := os.Getenv("GOOGLEWORKSPACE_DOMAIN")
+
+	if domainName == "" {
+		t.Skip("GOOGLEWORKSPACE_DOMAIN needs to be set to run this test")
+	}
+
+	impersonation := getTestImpersonatedUserFromEnv()
+	os.Unsetenv("GOOGLEWORKSPACE_IMPERSONATED_USER_EMAIL")
+	t.Cleanup(func() {
+		os.Setenv("GOOGLEWORKSPACE_IMPERSONATED_USER_EMAIL", impersonation)
+	})
+
+	testGroupVals := map[string]interface{}{
+		"domainName": domainName,
+		"email":      fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceGroup_basic(testGroupVals),
+			},
+			{
+				ResourceName:            "googleworkspace_group.my-group",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+		},
+	})
+}
+
+// this test requires the service account in the credentials file to have
 // USER MANAGEMENT ADMIN role assignment. Use the rest api
 // "Try this API" https://developers.google.com/admin-sdk/directory/reference/rest/v1/roleAssignments/insert
 // you will need to determine the roleId of _USER_MANAGEMENT_ADMIN_ROLE and use the client_id

--- a/internal/provider/provider_no_impersonation_test.go
+++ b/internal/provider/provider_no_impersonation_test.go
@@ -1,0 +1,51 @@
+package googleworkspace
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// this test requires the service account in the credentials file to have
+// USER MANAGEMENT ADMIN role assignment. Use the rest api
+// "Try this API" https://developers.google.com/admin-sdk/directory/reference/rest/v1/roleAssignments/insert
+// you will need to determine the roleId of _USER_MANAGEMENT_ADMIN_ROLE and use the client_id
+// in the credentials file as 'assignedTo', 'scopeType' should be 'CUSTOMER'
+func TestAccResourceUser_noImpersonation(t *testing.T) {
+	domainName := os.Getenv("GOOGLEWORKSPACE_DOMAIN")
+
+	if domainName == "" {
+		t.Skip("GOOGLEWORKSPACE_DOMAIN needs to be set to run this test")
+	}
+
+	impersonation := getTestImpersonatedUserFromEnv()
+	os.Unsetenv("GOOGLEWORKSPACE_IMPERSONATED_USER_EMAIL")
+	t.Cleanup(func() {
+		os.Setenv("GOOGLEWORKSPACE_IMPERSONATED_USER_EMAIL", impersonation)
+	})
+
+	testUserVals := map[string]interface{}{
+		"domainName": domainName,
+		"userEmail":  fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+		"password":   acctest.RandString(10),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceUser_basic(testUserVals),
+			},
+			{
+				ResourceName:            "googleworkspace_user.my-new-user",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag", "password"},
+			},
+		},
+	})
+}

--- a/internal/provider/resource_group_test.go
+++ b/internal/provider/resource_group_test.go
@@ -9,46 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// this test requires the service account in the credentials file to have
-// GROUPS ADMIN role assignment. Use the rest api
-// "Try this API" https://developers.google.com/admin-sdk/directory/reference/rest/v1/roleAssignments/insert
-// you will need to determine the roleId of GROUPS ADMIN and use the client_id
-// in the credentials file as 'assignedTo', 'scopeType' should be 'CUSTOMER'
-func TestAccResourceGroup_noImpersonation(t *testing.T) {
-	domainName := os.Getenv("GOOGLEWORKSPACE_DOMAIN")
-
-	if domainName == "" {
-		t.Skip("GOOGLEWORKSPACE_DOMAIN needs to be set to run this test")
-	}
-
-	impersonation := getTestImpersonatedUserFromEnv()
-	os.Unsetenv("GOOGLEWORKSPACE_IMPERSONATED_USER_EMAIL")
-	t.Cleanup(func() {
-		os.Setenv("GOOGLEWORKSPACE_IMPERSONATED_USER_EMAIL", impersonation)
-	})
-
-	testGroupVals := map[string]interface{}{
-		"domainName": domainName,
-		"email":      fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccResourceGroup_basic(testGroupVals),
-			},
-			{
-				ResourceName:            "googleworkspace_group.my-group",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag"},
-			},
-		},
-	})
-}
-
 func TestAccResourceGroup_basic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Description

I manually tested managing users by a service account with the User Management Admin system role granted in Google Workspace and found it worked as expected.

<img width="175" alt="Screenshot of User Management Admin system role in Google Workspace UI" src="https://user-images.githubusercontent.com/15078782/172266584-53ca3e20-13f4-480f-9fb1-108cd86d9593.png">

This test mimics an existing test that asserts that no impersonation is needed to manage groups. I've moved both 'no impersonation' tests into their own file.
