### PR TITLE
Fix inconsistent handling of group emails between `googleworkspace_group` and `googleworkspace_group_settings`

### DIFF
--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -42,9 +43,13 @@ func resourceGroup() *schema.Resource {
 			},
 			"email": {
 				Description: "The group's email address. If your account has multiple domains," +
-					"select the appropriate domain for the email address. The email must be unique.",
+					"select the appropriate domain for the email address. The email must be unique." +
+					"Values of `email` will be converted to lowercase by the API.",
 				Type:     schema.TypeString,
 				Required: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 			"name": {
 				Description: "The group's display name.",

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -110,6 +110,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	client := meta.(*apiClient)
 
 	email := d.Get("email").(string)
+	email = strings.ToLower(email)
 	log.Printf("[DEBUG] Creating Group %q: %#v", email, email)
 
 	directoryService, diags := client.NewDirectoryService()
@@ -123,7 +124,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	groupObj := directory.Group{
-		Email:       d.Get("email").(string),
+		Email:       email,
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
 	}

--- a/internal/provider/resource_group_settings.go
+++ b/internal/provider/resource_group_settings.go
@@ -526,7 +526,10 @@ func resourceGroupSettingsRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	d.Set("email", group.Email)
+	// Handle scenario importing group settings made with email containing upper case characters
+	emailDowncased := strings.ToLower(group.Email)
+
+	d.Set("email", emailDowncased)
 	d.Set("name", group.Name)
 	d.Set("description", group.Description)
 	d.Set("who_can_join", group.WhoCanJoin)

--- a/internal/provider/resource_group_settings.go
+++ b/internal/provider/resource_group_settings.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -40,6 +41,9 @@ func resourceGroupSettings() *schema.Resource {
 				Description: "The group's email address.",
 				Type:        schema.TypeString,
 				Required:    true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 			"name": {
 				Description: "Name of the group, which has a maximum size of 75 characters.",
@@ -359,6 +363,7 @@ func resourceGroupSettingsCreate(ctx context.Context, d *schema.ResourceData, me
 	client := meta.(*apiClient)
 
 	email := d.Get("email").(string)
+	email = strings.ToLower(email)
 	log.Printf("[DEBUG] Creating Group Settings %q: %#v", email, email)
 
 	groupsSettingsService, diags := client.NewGroupsSettingsService()

--- a/internal/provider/resource_group_settings_test.go
+++ b/internal/provider/resource_group_settings_test.go
@@ -3,6 +3,7 @@ package googleworkspace
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -18,9 +19,12 @@ func TestAccResourceGroupSettings_basic(t *testing.T) {
 		t.Skip("GOOGLEWORKSPACE_DOMAIN needs to be set to run this test")
 	}
 
+	emailInput := fmt.Sprintf("tf-test-%s-%s", acctest.RandString(10), "CASE-TEST")
+	expectedEmail := fmt.Sprintf("%s@%s", strings.ToLower(emailInput), domainName) // API lower-cases email
+
 	testGroupVals := map[string]interface{}{
 		"domainName": domainName,
-		"email":      fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+		"email":      emailInput,
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -29,6 +33,10 @@ func TestAccResourceGroupSettings_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceGroupSettings_basic(testGroupVals),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_group.my-group", "email", expectedEmail),
+					resource.TestCheckResourceAttr("googleworkspace_group_settings.my-group-settings", "email", expectedEmail),
+				),
 			},
 			{
 				ResourceName:      "googleworkspace_group_settings.my-group-settings",
@@ -48,9 +56,12 @@ func TestAccResourceGroupSettings_full(t *testing.T) {
 		t.Skip("GOOGLEWORKSPACE_DOMAIN needs to be set to run this test")
 	}
 
+	emailInput := fmt.Sprintf("tf-test-%s-%s", acctest.RandString(10), "CASE-TEST")
+	expectedEmail := fmt.Sprintf("%s@%s", strings.ToLower(emailInput), domainName) // API lower-cases email
+
 	testGroupVals := map[string]interface{}{
 		"domainName": domainName,
-		"email":      fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+		"email":      emailInput,
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -59,6 +70,10 @@ func TestAccResourceGroupSettings_full(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceGroupSettings_full(testGroupVals),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_group.my-group", "email", expectedEmail),
+					resource.TestCheckResourceAttr("googleworkspace_group_settings.my-group-settings", "email", expectedEmail),
+				),
 			},
 			{
 				ResourceName:      "googleworkspace_group_settings.my-group-settings",
@@ -67,6 +82,10 @@ func TestAccResourceGroupSettings_full(t *testing.T) {
 			},
 			{
 				Config: testAccResourceGroupSettings_fullUpdate(testGroupVals),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_group.my-group", "email", expectedEmail),
+					resource.TestCheckResourceAttr("googleworkspace_group_settings.my-group-settings", "email", expectedEmail),
+				),
 			},
 			{
 				ResourceName:      "googleworkspace_group.my-group",

--- a/internal/provider/resource_group_test.go
+++ b/internal/provider/resource_group_test.go
@@ -3,6 +3,7 @@ package googleworkspace
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -19,12 +20,13 @@ func TestAccResourceGroup_basic(t *testing.T) {
 		t.Skip("GOOGLEWORKSPACE_DOMAIN needs to be set to run this test")
 	}
 
+	emailInput := fmt.Sprintf("tf-test-%s-%s", acctest.RandString(10), "CASE-TEST")
+	expectedEmail := fmt.Sprintf("%s@%s", strings.ToLower(emailInput), domainName) // API lower-cases email
+
 	testGroupVals := map[string]interface{}{
 		"domainName": domainName,
-		"email":      fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+		"email":      emailInput,
 	}
-
-	expectedEmail := fmt.Sprintf("%s@%s", testGroupVals["email"].(string), testGroupVals["domainName"].(string))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -32,6 +34,9 @@ func TestAccResourceGroup_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceGroup_basic(testGroupVals),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_group.my-group", "email", expectedEmail),
+				),
 			},
 			{
 				// TestStep imports by `id` by default - an alphanumeric string


### PR DESCRIPTION
# PR Description

Closes https://github.com/hashicorp/terraform-provider-googleworkspace/issues/331

This PR makes the `email` field case insensitive on both `googleworkspace_group` and `googleworkspace_group_settings` resources, and also makes the provider convert the values to lower case when:
- creating a new resource of those types
- reading `googleworkspace_group_settings` resources

These changes are to solve several issues resulting from the Directory API endpoint for [converts emails to lowercase]((https://support.google.com/a/answer/9193374#:~:text=If%20you%20enter%20uppercase%20letters%20when%C2%A0creating%C2%A0a%C2%A0username%2C%20they%20are%20converted%20to%20lowercase%20letters)) when creating new groups. This causes perma-update issues with `googleworkspace_group` resources as Terraform tries to return the email to the original value. There's a more serious problem when `googleworkspace_group_settings` resources are in configurations - see the 2 scenarios described below

## Solution
- downcase `email` when creating new resources; avoid this issue perpetuating in future
- downcase `email` when importing a `googleworkspace_group_settings` resource; groups are downcased by Google's API so the equivalent change isn't needed for `googleworkspace_group`, but setting are always made with the capitalised email and cause issues.
- TBD : do we add validation? This would not technically be a breaking change and no resource deletion would be needed, but would require configuration changes and depends on how users got to their current configuration


# Problem notes

When groups are made the email is downcased by Google, but the group settings made on Google's backend uses the original upper case version of the email. This has these consequences:

## Scenario 1 -  Error: Provider produced inconsistent final plan, if create both resources in one `apply`

A configuration with these 2 resources being added in the same `apply` results in an internal error

```hcl
resource "googleworkspace_group" "test" {
  email = "sarah-test-CAPITAL-LETTERS@example.com"
  name = "sarah-test-CAPITAL-LETTERS"
}

resource "googleworkspace_group_settings" "test-settings" {
  email = googleworkspace_group.test.email

  allow_external_members = false

  who_can_join            = "INVITED_CAN_JOIN"
  who_can_view_membership = "ALL_MANAGERS_CAN_VIEW"
  who_can_post_message    = "ALL_MEMBERS_CAN_POST"
}
```

>│ Error: Provider produced inconsistent final plan
│ 
│ When expanding the plan for googleworkspace_group_settings.test-settings to include new values learned so far during apply, provider
│ "registry.terraform.io/hashicorp/googleworkspace" produced an invalid new value for .email: was cty.StringVal("sarah-test-CAPITAL-LETTERS@example.com"),
│ but now cty.StringVal("sarah-test-capital-letters@example.com").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.


## Scenario 2 -  Creating resources over multiple `apply` steps results in permadiff/400 error

Reproduced with these step using parts of the above configuration:

1. `googleworkspace_group` is made in a first apply step, using config as above. Settings are made on Google's backend as a side effect.
2. `googleworkspace_group` resource is updated to `ignore_changes` in the `email` field
3. `googleworkspace_group_settings` is added to the configuration and is 'created' successfully, i.e. it finds and starts managing the settings resource that has email set as `sarah-test-CAPITAL-LETTERS@example.com`
4. Subsequent `apply` commands experience a 400 error when Terraform performs an incomplete [`update`](https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups/update). action. The update action it's attempting to do is not allowed anyway, so this cannot be fixed. If it were fixed, there'd still be a permadiff error.
5. 400 errors can be stopped by updating the resource to `ignore_changes` in the `email` field.

Fixing explicit 400 error that occurs in this scenario results in a permanent perma-diff

# Possible solutions

## 1. Input Validation ⚠️ - breaking change

Stop practitioners having upper case characters in group emails, using a simple regex.

**PROS**:
- avoids issue completely for new groups made by TF

**CONS**:
- preexisting groups imported into state will still be affected by the issue

## 2. Down-case the email on the provider-side before creating the group ✅

**PROS**:
- avoids issue completely for new groups made by TF

**CONS**:
- preexisting groups imported into state will still be affected by the issue - **address this by downcasing on Read also** ✅
- configuration doesn't match what's made (but that's already the case!)

## 3. Use non-editable alias email to access group settings for a group ❌

When you make a group with an email containing capital letters the original upper case version of the email is reflected in the non-editable aliases.  I was able to use the `nonEditableAliases` email to update the group description via the [`update` endpoint](https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups/update) of the Group Settings API, and changing the provider to do this would avoid the permadiff...

**Edit:** I tried implementing this but then hit an issue where the client library forces the update requests to try and set the email as the alias, even when the provider code doesn't try to set it. It was already a hacky solution but this difficulty made me think it was a good time to stop.