### PR TITLE
Update documentation front-matter and inputs to `make generate`

### DIFF
--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -26,21 +26,22 @@ output "num_groups" {
 
 ### Read-Only
 
-- **groups** (List of Object) A list of Group resources. (see [below for nested schema](#nestedatt--groups))
-- **id** (String) The ID of this resource.
+- `groups` (List of Object) A list of Group resources. (see [below for nested schema](#nestedatt--groups))
+- `id` (String) The ID of this resource.
 
 <a id="nestedatt--groups"></a>
 ### Nested Schema for `groups`
 
 Read-Only:
 
-- **admin_created** (Boolean) Value is true if this group was created by an administrator rather than a user.
-- **aliases** (List of String) asps.list of group's email addresses.
-- **description** (String) An extended description to help users determine the purpose of a group.For example, you can include information about who should join the group,the types of messages to send to the group, links to FAQs about the group, or related groups.
-- **direct_members_count** (Number) The number of users that are direct members of the group.If a group is a member (child) of this group (the parent),members of the child group are not counted in the directMembersCount property of the parent group.
-- **etag** (String) ETag of the resource.
-- **name** (String) The group's display name.
-- **non_editable_aliases** (List of String) asps.list of the group's non-editable alias email addresses that are outside of the account's primary domain or subdomains. These are functioning email addresses used by the group.
-
+- `admin_created` (Boolean)
+- `aliases` (List of String)
+- `description` (String)
+- `direct_members_count` (Number)
+- `email` (String)
+- `etag` (String)
+- `id` (String)
+- `name` (String)
+- `non_editable_aliases` (List of String)
 
 

--- a/docs/guides/upgrade_guide.md
+++ b/docs/guides/upgrade_guide.md
@@ -3,7 +3,7 @@ layout: ""
 page_title: "Upgrading to the Google Workspace Provider"
 subcategory: ""
 description: |-
-Terraform Google Workspace Provider Upgrade Guide
+  Terraform Google Workspace Provider Upgrade Guide
 ---
 
 # Terraform Google Workspace Provider Upgrade Guide

--- a/docs/guides/upgrade_guide.md
+++ b/docs/guides/upgrade_guide.md
@@ -1,6 +1,8 @@
 ---
 page_title: "Upgrading to the Google Workspace Provider"
 subcategory: ""
+description: |-
+  Terraform Google Workspace Provider Upgrade Guide
 ---
 
 # Terraform Google Workspace Provider Upgrade Guide

--- a/docs/guides/upgrade_guide.md
+++ b/docs/guides/upgrade_guide.md
@@ -1,9 +1,6 @@
 ---
-layout: ""
 page_title: "Upgrading to the Google Workspace Provider"
 subcategory: ""
-description: |-
-  Terraform Google Workspace Provider Upgrade Guide
 ---
 
 # Terraform Google Workspace Provider Upgrade Guide

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ You do not need to set up domain-wide delegation if you are granting more specif
 
 To do this it's recommended that you create a custom admin role(s) with the Admin API privileges you need, as [pre-built administrator roles](https://support.google.com/a/answer/2405986) might not cover your use case.
 
-~> Some resources controlled via this provider can only be managed by a Super Admin, so user impersonation is necessary in those cases. For instance, [Admin Roles can only managed via the console or API by a Super Admin](https://support.google.com/a/answer/2406043?hl=en). Also, access to some API endpoints may not be possible to grant as privileges in custom roles. 
+~> Some resources controlled via this provider can only be managed by a Super Admin, so user impersonation is necessary in those cases. For instance, [Admin Roles can only be managed via the console or API by a Super Admin](https://support.google.com/a/answer/2406043?hl=en). Also, access to some API endpoints may not be possible to grant as privileges in custom roles. 
 
 When using gcloud locally, you can provide the required scopes for ADC login by adding the `--scopes` parameter to [`gcloud auth application-default login`](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login). For example, you can [provide additional scopes](https://cloud.google.com/sdk/gcloud/reference/beta/compute/instances/set-scopes) on Compute Engine. You can do this to configure access for both service accounts and end users.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ description: |-
 
 # Google Workspace Provider
 
-  The Google Workspace provider provides resources to interact with Google Workspace.
+The Google Workspace provider provides resources to interact with Google Workspace.
 
 ## Example Usage
 
@@ -89,7 +89,7 @@ You do not need to set up domain-wide delegation if you are granting more specif
 
 To do this it's recommended that you create a custom admin role(s) with the Admin API privileges you need, as [pre-built administrator roles](https://support.google.com/a/answer/2405986) might not cover your use case.
 
-~> Some resources controlled via this provider can only be managed by a Super Admin, so user impersonation is necessary in those cases. For instance, [Admin Roles can only be managed via the console or API by a Super Admin](https://support.google.com/a/answer/2406043?hl=en). Also, access to some API endpoints may not be possible to grant as privileges in custom roles. 
+~> Some resources controlled via this provider can only be managed by a Super Admin, so user impersonation is necessary in those cases. For instance, [Admin Roles can only managed via the console or API by a Super Admin](https://support.google.com/a/answer/2406043?hl=en). Also, access to some API endpoints may not be possible to grant as privileges in custom roles. 
 
 When using gcloud locally, you can provide the required scopes for ADC login by adding the `--scopes` parameter to [`gcloud auth application-default login`](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login). For example, you can [provide additional scopes](https://cloud.google.com/sdk/gcloud/reference/beta/compute/instances/set-scopes) on Compute Engine. You can do this to configure access for both service accounts and end users.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: ""
 page_title: "Google Workspace Provider"
 subcategory: ""
 description: |-
-The Google Workspace provider provides resources to interact with Google Workspace.
+  The Google Workspace provider provides resources to interact with Google Workspace.
 ---
 
 # Google Workspace Provider

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,6 @@
 ---
-layout: ""
 page_title: "Google Workspace Provider"
 subcategory: ""
-description: |-
-  The Google Workspace provider provides resources to interact with Google Workspace.
 ---
 
 # Google Workspace Provider

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 ---
 page_title: "Google Workspace Provider"
 subcategory: ""
+description: |-
+  The Google Workspace provider provides resources to interact with Google Workspace.
 ---
 
 # Google Workspace Provider

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -182,11 +182,7 @@ Read-Only:
 
 Required:
 
-- `type` (String) The address type. Acceptable values: 
-	- `custom`
-	- `home`
-	- `other`
-	- `work`
+- `type` (String) The address type. Acceptable values: `custom`, `home`, `other`, `work`.
 
 Optional:
 
@@ -218,11 +214,7 @@ Required:
 
 Required:
 
-- `type` (String) The type of the email account. Acceptable values:
-	- `custom`,
-	- `home`,
-	- `other`,
-	- `work`.
+- `type` (String) The type of the email account. Acceptable values: `custom`, `home`, `other`, `work`.
 
 Optional:
 
@@ -236,13 +228,7 @@ Optional:
 
 Required:
 
-- `type` (String) The type of external ID. If set to custom, customType must also be set. Acceptable values: 
-	- `account`
-	- `custom`
-	- `customer`
-	- `login_id`
-	- `network`
-	- `organization`
+- `type` (String) The type of external ID. If set to custom, customType must also be set. Acceptable values: `account`, `custom`, `customer`, `login_id`, `network`, `organization`.
 - `value` (String) The value of the ID.
 
 Optional:
@@ -255,22 +241,8 @@ Optional:
 
 Required:
 
-- `protocol` (String) An IM protocol identifies the IM network. The value can be a custom network or the standard network. Acceptable values: 
-	- `aim`
-	- `custom_protocol`
-	- `gtalk`
-	- `icq`
-	- `jabber`
-	- `msn`
-	- `net_meeting`
-	- `qq`
-	- `skype`
-	- `yahoo`
-- `type` (String) Acceptable values: 
-	- `custom`
-	- `home`
-	- `other`
-	- `work`
+- `protocol` (String) An IM protocol identifies the IM network. The value can be a custom network or the standard network. Acceptable values: `aim`, `custom_protocol`, `gtalk`, `icq`, `jabber`, `msn`, `net_meeting`, `qq`, `skype`, `yahoo`.
+- `type` (String) Acceptable values: `custom`, `home`, `other`, `work`.
 
 Optional:
 
@@ -285,11 +257,7 @@ Optional:
 
 Required:
 
-- `type` (String) Each entry can have a type which indicates standard type of that entry. For example, keyword could be of type occupation or outlook. In addition to the standard type, an entry can have a custom type and can give it any name. Such types should have the CUSTOM value as type and also have a customType value. Acceptable values: 
-	- `custom`
-	- `mission`
-	- `occupation`
-	- `outlook`
+- `type` (String) Each entry can have a type which indicates standard type of that entry. For example, keyword could be of type occupation or outlook. In addition to the standard type, an entry can have a custom type and can give it any name. Such types should have the CUSTOM value as type and also have a customType value. Acceptable values: `custom`, `mission`, `occupation`, `outlook`
 - `value` (String) Keyword.
 
 Optional:
@@ -312,10 +280,7 @@ Optional:
 
 Required:
 
-- `type` (String) The location type. Acceptable values: 
-	- `custom`
-	- `default`
-	- `desk`
+- `type` (String) The location type. Acceptable values: `custom`, `default`, `desk`
 
 Optional:
 
@@ -332,11 +297,7 @@ Optional:
 
 Required:
 
-- `type` (String) The type of organization. Acceptable values: 
-	- `domain_only`
-	- `school`
-	- `unknown`
-	- `work`.
+- `type` (String) The type of organization. Acceptable values: `domain_only`, `school`, `unknown`, `work`.
 
 Optional:
 
@@ -358,28 +319,7 @@ Optional:
 
 Required:
 
-- `type` (String) The type of phone number. Acceptable values: 
-	- `assistant`
-	- `callback`
-	- `car`
-	- `company_main`
-	- `custom`
-	- `grand_central`
-	- `home`
-	- `home_fax`
-	- `isdn`
-	- `main`
-	- `mobile`
-	- `other`
-	- `other_fax`
-	- `pager`
-	- `radio`
-	- `telex`
-	- `tty_tdd`
-	- `work`
-	- `work_fax`
-	- `work_mobile`
-	- `work_pager`
+- `type` (String) The type of phone number. Acceptable values: `assistant`, `callback`, `car`, `company_main` , `custom`, `grand_central`, `home`, `home_fax`, `isdn`, `main`, `mobile`, `other`, `other_fax`, `pager`, `radio`, `telex`, `tty_tdd`, `work`, `work_fax`, `work_mobile`, `work_pager`.
 - `value` (String) A human-readable phone number. It may be in any telephone number format.
 
 Optional:
@@ -397,10 +337,7 @@ Optional:
 - `gecos` (String) The GECOS (user information) for this account.
 - `gid` (String) The default group ID.
 - `home_directory` (String) The path to the home directory for this account.
-- `operating_system_type` (String) The operating system type for this account. Acceptable values: 
-	- `linux`
-	- `unspecified`
-	- `windows`
+- `operating_system_type` (String) The operating system type for this account. Acceptable values: `linux`, `unspecified`, `windows`.
 - `primary` (Boolean) If this is user's primary account within the SystemId.
 - `shell` (String) The path to the login shell for this account.
 - `system_id` (String) System identifier for which account Username or Uid apply to.
@@ -413,25 +350,7 @@ Optional:
 
 Required:
 
-- `type` (String) The type of relation. Acceptable values: 
-	- `admin_assistant`
-	- `assistant`
-	- `brother`
-	- `child`
-	- `custom`
-	- `domestic_partner`
-	- `dotted_line_manager`
-	- `exec_assistant`
-	- `father`
-	- `friend`
-	- `manager`
-	- `mother`
-	- `parent`
-	- `partner`
-	- `referred_by`
-	- `relative`
-	- `sister`
-	- `spouse`
+- `type` (String) The type of relation. Acceptable values: `admin_assistant`, `assistant`, `brother`, `child`, `custom`, `domestic_partner`, `dotted_line_manager`, `exec_assistant`, `father`, `friend`, `manager`, `mother`, `parent`, `partner`, `referred_by`, `relative`, `sister`, `spouse`.
 - `value` (String) The name of the person the user is related to.
 
 Optional:
@@ -469,18 +388,7 @@ Optional:
 
 Required:
 
-- `type` (String) The type or purpose of the website. For example, a website could be labeled as home or blog. Alternatively, an entry can have a custom type Custom types must have a customType value. Acceptable values: 
-	- `app_install_page`
-	- `blog`
-	- `custom`
-	- `ftp`
-	- `home`
-	- `home_page`
-	- `other`
-	- `profile`
-	- `reservations`
-	- `resume`
-	- `work`
+- `type` (String) The type or purpose of the website. For example, a website could be labeled as home or blog. Alternatively, an entry can have a custom type Custom types must have a customType value. Acceptable values: `app_install_page`, `blog`, `custom`, `ftp` , `home`, `home_page`, `other`, `profile`, `reservations`, `resume`, `work`.
 - `value` (String) The URL of the website.
 
 Optional:
@@ -497,5 +405,3 @@ terraform import googleworkspace_user.dwight 123456789012345678901
 # or with email as id
 terraform import googleworkspace_user.dwight dwight.schrute@example.com
 ```
-
-

--- a/examples/resources/googleworkspace_group/import.sh
+++ b/examples/resources/googleworkspace_group/import.sh
@@ -1,1 +1,3 @@
 terraform import googleworkspace_group.sales 01abcde23fg4h5i
+# or with email as id
+terraform import googleworkspace_group.sales sales@example.com

--- a/examples/resources/googleworkspace_user/import.sh
+++ b/examples/resources/googleworkspace_user/import.sh
@@ -1,1 +1,3 @@
 terraform import googleworkspace_user.dwight 123456789012345678901
+# or with email as id
+terraform import googleworkspace_user.dwight dwight.schrute@example.com

--- a/templates/guides/upgrade_guide.md
+++ b/templates/guides/upgrade_guide.md
@@ -3,7 +3,7 @@ layout: ""
 page_title: "Upgrading to the Google Workspace Provider"
 subcategory: ""
 description: |-
-Terraform Google Workspace Provider Upgrade Guide
+  Terraform Google Workspace Provider Upgrade Guide
 ---
 
 # Terraform Google Workspace Provider Upgrade Guide

--- a/templates/guides/upgrade_guide.md
+++ b/templates/guides/upgrade_guide.md
@@ -1,6 +1,8 @@
 ---
 page_title: "Upgrading to the Google Workspace Provider"
 subcategory: ""
+description: |-
+  Terraform Google Workspace Provider Upgrade Guide
 ---
 
 # Terraform Google Workspace Provider Upgrade Guide

--- a/templates/guides/upgrade_guide.md
+++ b/templates/guides/upgrade_guide.md
@@ -1,9 +1,6 @@
 ---
-layout: ""
 page_title: "Upgrading to the Google Workspace Provider"
 subcategory: ""
-description: |-
-  Terraform Google Workspace Provider Upgrade Guide
 ---
 
 # Terraform Google Workspace Provider Upgrade Guide

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -3,12 +3,12 @@ layout: ""
 page_title: "Google Workspace Provider"
 subcategory: ""
 description: |-
-The Google Workspace provider provides resources to interact with Google Workspace.
+  The Google Workspace provider provides resources to interact with Google Workspace.
 ---
 
 # Google Workspace Provider
 
-  The Google Workspace provider provides resources to interact with Google Workspace.
+The Google Workspace provider provides resources to interact with Google Workspace.
 
 ## Example Usage
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -65,7 +65,7 @@ You do not need to set up domain-wide delegation if you are granting more specif
 
 To do this it's recommended that you create a custom admin role(s) with the Admin API privileges you need, as [pre-built administrator roles](https://support.google.com/a/answer/2405986) might not cover your use case.
 
-~> Some resources controlled via this provider can only be managed by a Super Admin, so user impersonation is necessary in those cases. For instance, [Admin Roles can only managed via the console or API by a Super Admin](https://support.google.com/a/answer/2406043?hl=en). Also, access to some API endpoints may not be possible to grant as privileges in custom roles. 
+~> Some resources controlled via this provider can only be managed by a Super Admin, so user impersonation is necessary in those cases. For instance, [Admin Roles can only be managed via the console or API by a Super Admin](https://support.google.com/a/answer/2406043?hl=en). Also, access to some API endpoints may not be possible to grant as privileges in custom roles. 
 
 When using gcloud locally, you can provide the required scopes for ADC login by adding the `--scopes` parameter to [`gcloud auth application-default login`](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login). For example, you can [provide additional scopes](https://cloud.google.com/sdk/gcloud/reference/beta/compute/instances/set-scopes) on Compute Engine. You can do this to configure access for both service accounts and end users.
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -1,9 +1,6 @@
 ---
-layout: ""
 page_title: "Google Workspace Provider"
 subcategory: ""
-description: |-
-  The Google Workspace provider provides resources to interact with Google Workspace.
 ---
 
 # Google Workspace Provider

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -1,6 +1,8 @@
 ---
 page_title: "Google Workspace Provider"
 subcategory: ""
+description: |-
+  The Google Workspace provider provides resources to interact with Google Workspace.
 ---
 
 # Google Workspace Provider


### PR DESCRIPTION
This PR is reducing the diffs between our current docs and what is produced when `make generate` is run to regenerate the documentation. Commit messages should make it clear why different things have been changed! I also identified some unused frontmatter by looking at this [section of the docs](https://www.terraform.io/registry/providers/docs#yaml-frontmatter)

For this PR I was originally looking into why the Registry didn't using the front matter to set the link text in the way I expected:

<img width="213" alt="Screenshot 2022-07-05 at 11 47 47" src="https://user-images.githubusercontent.com/15078782/177345596-b4f327eb-59f7-4123-9181-7a26393039dc.png">

This seems to be due to an indentation issue, but when I asked the Registry team for help I learned that the `layout` field isn't necessary anymore and that the `description` field is maybe used/maybe not used. The `description` field is meant to be used for meta tags in the Registry's HTML (learned this talking to Brian Flad) but it doesn't appear like this is being done at the moment .

Because of the above I've removed `layout` and kept `description` for now