### PR TITLE
[#362] New Access Token Env Var

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -57,6 +57,7 @@ func New(version string) func() *schema.Provider {
 						"used over the `credentials` field.",
 					Type: schema.TypeString,
 					DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+						"GOOGLEWORKSPACE_ACCESS_TOKEN",
 						"GOOGLE_OAUTH_ACCESS_TOKEN",
 					}, nil),
 					Optional: true,


### PR DESCRIPTION
Along the lines of #362:

Adding a separate env var called `GOOGLEWORKSPACE_ACCESS_TOKEN` as a higher priority way to set an access token in the environment. Why:

We use the `googleworkspace` provider alongside the `google` provider (use in same root modules), therefore we want / need the access token used for the former to have different permissions / scopes from the latter. To use them at the same time, we have to have separate tokens set.