### PR TITLE
Fix: group membership import documentation

### DIFF
--- a/docs/resources/group_member.md
+++ b/docs/resources/group_member.md
@@ -82,5 +82,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import googleworkspace_group_member.manager groups/01abcde23fg4h5i/members/123456789012345678901
+terraform import googleworkspace_group_member.manager groups/01abcde23fg4h5i/members/dwight.schrute@example.com
 ```


### PR DESCRIPTION
When trying to import using the userID (as per the documentation), we get the following error:

`Error when reading or editing groups/GROUP_ID/members/USER_ID: googleapi: Error 400: Missing required field: memberKey, required`

However, using email instead makes the import work 🙂 

@SarahFrench (or whomever else), is there any chance of this provider getting a few PRs merged?