### PR TITLE
Add ALL_OWNERS_CAN_LEAVE for who_can_leave_group

### DIFF
--- a/docs/data-sources/group_settings.md
+++ b/docs/data-sources/group_settings.md
@@ -90,6 +90,7 @@ output "who_can_join_sales" {
 - `who_can_leave_group` (String) Permission to leave the group. Possible values are:
 	- `ALL_MANAGERS_CAN_LEAVE`
 	- `ALL_MEMBERS_CAN_LEAVE`
+	- `ALL_OWNERS_CAN_LEAVE`
 	- `NONE_CAN_LEAVE`
 - `who_can_moderate_content` (String) Specifies who can moderate content. Possible values are: 
 	- `ALL_MEMBERS`

--- a/docs/resources/group_settings.md
+++ b/docs/resources/group_settings.md
@@ -93,6 +93,7 @@ resource "googleworkspace_group_settings" "sales-settings" {
 - `who_can_leave_group` (String) Defaults to `ALL_MEMBERS_CAN_LEAVE`. Permission to leave the group. Possible values are:
 	- `ALL_MANAGERS_CAN_LEAVE`
 	- `ALL_MEMBERS_CAN_LEAVE`
+	- `ALL_OWNERS_CAN_LEAVE`
 	- `NONE_CAN_LEAVE`
 - `who_can_moderate_content` (String) Defaults to `OWNERS_AND_MANAGERS`. Specifies who can moderate content. Possible values are: 
 	- `ALL_MEMBERS`

--- a/internal/provider/resource_group_settings.go
+++ b/internal/provider/resource_group_settings.go
@@ -264,12 +264,13 @@ func resourceGroupSettings() *schema.Resource {
 				Description: "Permission to leave the group. Possible values are:" +
 					"\n\t- `ALL_MANAGERS_CAN_LEAVE`" +
 					"\n\t- `ALL_MEMBERS_CAN_LEAVE`" +
+					"\n\t- `ALL_OWNERS_CAN_LEAVE`" +
 					"\n\t- `NONE_CAN_LEAVE`",
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "ALL_MEMBERS_CAN_LEAVE",
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"ALL_MANAGERS_CAN_LEAVE",
-					"ALL_MEMBERS_CAN_LEAVE", "NONE_CAN_LEAVE"}, true)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+					"ALL_MANAGERS_CAN_LEAVE", "ALL_MEMBERS_CAN_LEAVE", "ALL_OWNERS_CAN_LEAVE", "NONE_CAN_LEAVE"}, true)),
 			},
 			"who_can_contact_owner": {
 				Description: "Permission to contact owner of the group via web UI. Possible values are: " +


### PR DESCRIPTION
We are working to import google resources and I see that existing value for one of our groups is ALL_OWNERS_CAN_LEAVE.

```
  # googleworkspace_group_settings.this["<obfuscated>"] will be updated in-place
  ~ resource "googleworkspace_group_settings" "this" {
        id                                             = "<obfuscated>@<obfuscated>"
        name                                           = "<obfuscated>"
      ~ who_can_leave_group                            = "ALL_OWNERS_CAN_LEAVE" -> "ALL_MEMBERS_CAN_LEAVE"
        # (24 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```

If I change to it, provider crashes with:

```
│ Error: expected who_can_leave_group to be one of [ALL_MANAGERS_CAN_LEAVE ALL_MEMBERS_CAN_LEAVE NONE_CAN_LEAVE], got ALL_OWNERS_CAN_LEAVE
│
│   with googleworkspace_group_settings.this["<obfuscated>"],
│   on groups.tf line 26, in resource "googleworkspace_group_settings" "this":
│   26:   who_can_leave_group        = try(each.value.who_can_leave_group, null)
```

Tested with built provider and the diff went away, should be fine I think.