### PR TITLE
Resolve bug in validation of a chrome_policy resource with multiple schema_values of differing types bug

### DIFF
--- a/internal/provider/resource_chrome_policy_test.go
+++ b/internal/provider/resource_chrome_policy_test.go
@@ -172,6 +172,16 @@ func TestAccResourceChromePolicy_multiple(t *testing.T) {
 					testCheck,
 				),
 			},
+			{
+				Config: testAccResourceChromePolicy_multipleValueTypes(ouName, true, "POLICY_MODE_RECOMMENDED"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.#", "1"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_name", "chrome.users.DomainReliabilityAllowed"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_values.domainReliabilityAllowed", "true"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_values.domainReliabilityAllowedSettingGroupPolicyMode", encode("POLICY_MODE_RECOMMENDED")),
+					testCheck,
+				),
+			},
 		},
 	})
 }
@@ -254,6 +264,26 @@ resource "googleworkspace_chrome_policy" "test" {
   }
 }
 `, ouName, enabled, pattern)
+}
+
+func testAccResourceChromePolicy_multipleValueTypes(ouName string, enabled bool, policyMode string) string {
+	return fmt.Sprintf(`
+resource "googleworkspace_org_unit" "test" {
+  name = "%s"
+  parent_org_unit_path = "/"
+}
+
+resource "googleworkspace_chrome_policy" "test" {
+  org_unit_id = googleworkspace_org_unit.test.id
+  policies {
+    schema_name = "chrome.users.DomainReliabilityAllowed"
+    schema_values = {
+	  domainReliabilityAllowed                       = jsonencode(%t)
+      domainReliabilityAllowedSettingGroupPolicyMode = jsonencode("%s")
+    }
+  }
+}
+`, ouName, enabled, policyMode)
 }
 
 func testAccResourceChromePolicy_basic(ouName string, conns int) string {


### PR DESCRIPTION
Seeks to resolve #471

### changes

Validation of chrome policy schema_values now expects there to always be exactly one [proto field](https://pkg.go.dev/google.golang.org/api@v0.86.0/chromepolicy/v1#Proto2FieldDescriptorProto) for any given schema_value. Previously all values were validated iteratively against all proto fields. This change seems reasonable - I don't believe it breaks an edge case. My test workspace's full policy schema does not have any schemas with conflicting field names.

But I'm unsure why the validation was first written this way. Concerning - Chesteron's fence, etc. (Git blame points to the [initial commit](https://github.com/hashicorp/terraform-provider-googleworkspace/blame/main/internal/provider/resource_chrome_policy.go#L334) only.) It may simply be a mistake which arose from a misunderstanding of (or changes in) schema structure. Or the misunderstanding may turn out to be mine :)!

I've added a relevant test case.