### PR TITLE
PSS-277: Bump hashicorp/ghaction-terraform-provider-release/.github/w…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
   terraform-provider-release:
     name: 'Terraform Provider Release'
     needs: [go-version, release-notes]
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v4.0.1
     secrets:
       hc-releases-key-prod: '${{ secrets.HC_RELEASES_KEY_PROD }}'
       hc-releases-key-staging: '${{ secrets.HC_RELEASES_KEY_STAGING }}'


### PR DESCRIPTION
…orkflows/hashicorp.yml to v4.0.1

This patch bumps hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml to v4.0.1, with the intention of using the new runner labels format (see release notes in https://github.com/hashicorp/ghaction-terraform-provider-release/releases/tag/v4.0.1).

This change is necessary for a runner to pick up jobs using this action.