### PR TITLE
Copying PR 488 from original repo

### DIFF
--- a/internal/provider/eventual_consistency.go
+++ b/internal/provider/eventual_consistency.go
@@ -8,7 +8,7 @@ import (
 )
 
 // The number of consistent responses we want before we consider the resource consistent
-const numConsistent = 4
+const numConsistent = 2
 
 type consistencyCheck struct {
 	currConsistent int

--- a/internal/provider/eventual_consistency_test.go
+++ b/internal/provider/eventual_consistency_test.go
@@ -42,8 +42,8 @@ func TestConsistencyCheckReachedConsistency(t *testing.T) {
 		t.Errorf("Failed: reached consistency (numInserts: %d, currConsistent: %d, etagChanges: %d, timeout: %d)", numInserts, cc.currConsistent, cc.etagChanges, int(cc.timeout.Minutes()))
 	}
 
-	// We've seen all the inserts come through, and it's been consistent 4 times
-	cc.currConsistent = 4
+	// We've seen all the inserts come through, and it's been consistent 2 times
+	cc.currConsistent = 2
 
 	if !cc.reachedConsistency(numInserts) {
 		t.Errorf("Failed: did not reach consistency (numInserts: %d, currConsistent: %d, etagChanges: %d, timeout: %d)", numInserts, cc.currConsistent, cc.etagChanges, int(cc.timeout.Minutes()))


### PR DESCRIPTION
Apologies for this, I didn't realise I was merging into hashicorp's repo.



Copying this pull request: https://github.com/hashicorp/terraform-provider-googleworkspace/pull/488#issue-2570424178

> # Change numConsistent from 4 to 2 in eventual consistency check
> ## Description
> This PR modifies the `numConsistent` constant in the eventual consistency check mechanism, reducing it from 4 to 2. This change aims to optimize the consistency check process by requiring fewer consistent reads before considering a resource state as consistent.
> 
> ## Changes
> * Updated `numConsistent` constant in `internal/provider/eventual_consistency.go` from 4 to 2
> * Modified test cases in `internal/provider/eventual_consistency_test.go` to align with the new `numConsistent` value
> 
> ## Motivation and Context
> * fix issue [Occasional timeout when applying the `googleworkspace_group_member` resource #475](https://github.com/hashicorp/terraform-provider-googleworkspace/issues/475)
> * The previous value of 4 for `numConsistent` may have been overly conservative, potentially leading to timeouts in resource operations. By reducing this to 2, we aim to strike a better balance between ensuring consistency and avoiding unnecessary timeouts in resource provisioning